### PR TITLE
fix(Responder) Reset response content when sending

### DIFF
--- a/Responder.php
+++ b/Responder.php
@@ -179,6 +179,8 @@ class Responder extends Connection
      */
     public function send(array $headers, $content = null)
     {
+        $this->_content = null;
+
         $client = $this->getClient();
         $client->connect();
         $client->setStreamBlocking(true);


### PR DESCRIPTION
Related to #18, #19.

Reset the response content before sending any message, to prevent having the response content of the previous exchange when the current one fails.