### PR TITLE
Extract buildResponseHeaders Method

### DIFF
--- a/Responder.php
+++ b/Responder.php
@@ -291,15 +291,25 @@ class Responder extends Connection
         }
 
         $pos     = strpos($responseOutput, "\r\n\r\n");
-        $headers = substr($responseOutput, 0, $pos);
 
+        $this->buildResponseHeaders(substr($responseOutput, 0, $pos));
+
+        return $this->_responseOutput = substr($responseOutput, $pos + 4);
+    }
+
+    /**
+     * Build the response header array.
+     *
+     * @param  string  $headers  The response header string
+     * @return void
+     */
+    protected function buildResponseHeaders($headers)
+    {
         foreach (explode("\r\n", $headers) as $header) {
             $semicolon = strpos($header, ':');
             $this->_responseHeaders[strtolower(trim(substr($header, 0, $semicolon)))]
                 = trim(substr($header, $semicolon + 1));
         }
-
-        return $this->_responseOutput = substr($responseOutput, $pos + 4);
     }
 
     /**


### PR DESCRIPTION
As noted on the open header issue raised by another user, parsing headers is broken for headers that may have multiple values. For example, a Symfony or Laravel application that sets two cookies, thus creating two `Set-Cookie` headers in the response. The last `Set-Cookie` header will be the only one included in the response.

While this does not fix that bug, which would be a larger breaking change since each header key would need to be an array of values, it does extract the header parsing logic into a separate method so that users may customize and thus fix the logic in their own applications if needed until a fix is provided in a major version.

Currently, I have to fix this behavior by overriding the entire `send` method.