### PR TITLE
Adding Multi headers Support

### DIFF
--- a/Responder.php
+++ b/Responder.php
@@ -159,7 +159,7 @@ class Responder extends Connection
     protected $_responseHeaders = [];
 
     /**
-     * Response's output.
+     * Expected Header type.
      *
      * @var string
      */


### PR DESCRIPTION
When we want to use Lambda integration with an ALB we must also enable Multi Header in our Load Balancer.

This PR enables it and also keeps the default functionality  of non-Multi Header as the default one.

We will only process multiheaders if specified by the `$_multiHeader ` variable.

